### PR TITLE
Add nix flake support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1626834727,
+        "narHash": "sha256-ToGgus+UImnLNaLgv+xfo/cI3J/NQl2KB5kvyErXays=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "63ee5cd99a2e193d5e4c879feb9683ddec23fa03",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-21.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,39 @@
+{
+  description = "4dl - 4chan image downloader written in bash";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-21.05";
+  };
+  outputs = { self, nixpkgs, ... }@inputs: let
+    systems = [ "x86_64-linux" "i686-linux" "aarch64-linux" ];
+    forSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
+    nixpkgsFor = forSystems (system: import nixpkgs { inherit system; });
+  in {
+    defaultApp = forSystems (system: {
+      type = "app";
+      program = "${self.defaultPackage.${system}}/bin/4dl";
+    });
+
+    defaultPackage = forSystems (system:
+    let
+      pkgs = nixpkgsFor.${system};
+      deps = with pkgs; [
+        coreutils gnused gawk gnugrep
+        findutils # for xargs
+        ncurses # for tput
+        util-linuxMinimal # for column
+        fd
+        curl jq wget
+        dateutils
+        recode
+      ];
+      binPath = nixpkgs.lib.makeBinPath deps;
+    in pkgs.runCommandLocal "4dl" {
+      nativeBuildInputs = [ pkgs.makeWrapper ];
+    } ''
+      mkdir -p $out/bin
+      cp ${./4dl} $out/bin/4dl
+      patchShebangs $out/bin/4dl
+      wrapProgram $out/bin/4dl --prefix PATH : ${binPath}
+    '');
+  };
+}


### PR DESCRIPTION
This allows users of [Nix, the purely functional package manager](https://nixos.org) to run this tool without installing, using a feature of Nix called flakes.

For example, to open a shell in which `4dl` is made available in `$PATH`:
```
nix shell github:numpadd/4dl
```

Or to run the script directly:
```
nix run github:numpadd/4dl https://boards.4channel.org/board/threadnumber ~/Pictures/directory
```

Or to quickly install this program in a per-user profile:
```
nix profile install github:numpadd/4dl
```